### PR TITLE
feat: support feishu region and remove unapproved scopes

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/yjwong/lark-cli/internal/auth"
+	"github.com/yjwong/lark-cli/internal/config"
 )
 
 const (
-	baseURL        = "https://open.larksuite.com/open-apis"
 	defaultTimeout = 30 * time.Second
 )
 
@@ -46,7 +46,7 @@ func (c *Client) doRequest(method, path string, body interface{}, result interfa
 		reqBody = bytes.NewBuffer(jsonBody)
 	}
 
-	url := baseURL + path
+	url := config.GetBaseURL() + path
 	req, err := http.NewRequest(method, url, reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -121,7 +121,7 @@ func (c *Client) doRequestWithTenantToken(method, path string, body interface{},
 		reqBody = bytes.NewBuffer(jsonBody)
 	}
 
-	url := baseURL + path
+	url := config.GetBaseURL() + path
 	req, err := http.NewRequest(method, url, reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
@@ -178,7 +178,7 @@ func (c *Client) DownloadWithTenantToken(path string) (io.ReadCloser, string, er
 		return nil, "", err
 	}
 
-	url := baseURL + path
+	url := config.GetBaseURL() + path
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create request: %w", err)
@@ -213,7 +213,7 @@ func (c *Client) Download(path string) (io.ReadCloser, string, error) {
 		return nil, "", err
 	}
 
-	url := baseURL + path
+	url := config.GetBaseURL() + path
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create request: %w", err)

--- a/internal/api/messages.go
+++ b/internal/api/messages.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 
 	"github.com/yjwong/lark-cli/internal/auth"
+	"github.com/yjwong/lark-cli/internal/config"
 )
 
 // ListMessagesOptions contains optional parameters for ListMessages
@@ -161,7 +162,7 @@ func (c *Client) UploadMessageImage(filePath string) (string, error) {
 		return "", fmt.Errorf("failed to finalize upload: %w", err)
 	}
 
-	url := baseURL + "/im/v1/images"
+	url := config.GetBaseURL() + "/im/v1/images"
 	req, err := http.NewRequest("POST", url, &buf)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %w", err)

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -18,11 +18,23 @@ import (
 )
 
 const (
-	authorizationURL     = "https://accounts.larksuite.com/open-apis/authen/v1/authorize"
-	tokenURL             = "https://open.larksuite.com/open-apis/authen/v2/oauth/token"
-	tenantTokenURL       = "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal"
-	defaultTimeout       = 5 * time.Minute
+	defaultTimeout = 5 * time.Minute
 )
+
+func getAuthorizationURL() string {
+	if config.GetRegion() == "feishu" {
+		return "https://accounts.feishu.cn/open-apis/authen/v1/authorize"
+	}
+	return "https://accounts.larksuite.com/open-apis/authen/v1/authorize"
+}
+
+func getTokenURL() string {
+	return config.GetBaseURL() + "/authen/v2/oauth/token"
+}
+
+func getTenantTokenURL() string {
+	return config.GetBaseURL() + "/auth/v3/tenant_access_token/internal"
+}
 
 // TokenResponse represents the OAuth token response from Lark
 type TokenResponse struct {
@@ -232,7 +244,7 @@ func RefreshTenantToken() error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", tenantTokenURL, bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequest("POST", getTenantTokenURL(), bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
@@ -290,7 +302,7 @@ func buildAuthorizationURL(appID, redirectURI, state, scopeString string) string
 	params.Set("scope", scopeString)
 	params.Set("state", state)
 
-	return authorizationURL + "?" + params.Encode()
+	return getAuthorizationURL() + "?" + params.Encode()
 }
 
 // exchangeCodeForTokens exchanges the authorization code for access tokens
@@ -325,7 +337,7 @@ func doTokenRequest(reqBody map[string]string) (*TokenResponse, error) {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", tokenURL, bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequest("POST", getTokenURL(), bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	AppID     string `mapstructure:"app_id"`
 	AppSecret string `mapstructure:"app_secret"`
+	Region    string `mapstructure:"region"`
 	Defaults  struct {
 		Timezone        string `mapstructure:"timezone"`
 		ReminderMinutes int    `mapstructure:"reminder_minutes"`
@@ -63,11 +64,13 @@ func Init() error {
 	viper.SetDefault("defaults.timezone", "Asia/Singapore")
 	viper.SetDefault("defaults.reminder_minutes", 15)
 	viper.SetDefault("oauth.redirect_port", 9999)
+	viper.SetDefault("region", "lark")
 
 	// Environment variable bindings
 	viper.SetEnvPrefix("LARK")
 	viper.BindEnv("app_id", "LARK_APP_ID")
 	viper.BindEnv("app_secret", "LARK_APP_SECRET")
+	viper.BindEnv("region", "LARK_REGION")
 
 	// Read config file (if exists)
 	if err := viper.ReadInConfig(); err != nil {
@@ -126,4 +129,17 @@ func TenantTokensFilePath() string {
 // GetCustomEmojis returns the custom emoji mappings
 func GetCustomEmojis() map[string]string {
 	return viper.GetStringMapString("custom_emojis")
+}
+
+// GetRegion returns the configured region ("lark" or "feishu")
+func GetRegion() string {
+	return viper.GetString("region")
+}
+
+// GetBaseURL returns the API base URL for the configured region
+func GetBaseURL() string {
+	if GetRegion() == "feishu" {
+		return "https://open.feishu.cn/open-apis"
+	}
+	return "https://open.larksuite.com/open-apis"
 }

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -24,13 +24,13 @@ var Groups = map[string]ScopeGroup{
 	"contacts": {
 		Name:        "contacts",
 		Description: "Company directory lookup",
-		Scopes:      []string{"contact:contact.base:readonly", "contact:department.base:readonly", "contact:department.organize:readonly", "contact:user:search"},
+		Scopes:      []string{"contact:contact.base:readonly", "contact:department.base:readonly", "contact:user:search"},
 		Commands:    []string{"contact"},
 	},
 	"documents": {
 		Name:        "documents",
 		Description: "Lark Docs and Drive access",
-		Scopes:      []string{"docx:document:readonly", "docx:document", "docx:document:create", "docs:doc:readonly", "docs:document.content:read", "docs:document.comment:read", "drive:drive:readonly", "wiki:wiki:readonly", "space:document:retrieve"},
+		Scopes:      []string{"docx:document:readonly", "docx:document", "docx:document:create", "docs:document.content:read", "docs:document.comment:read", "wiki:wiki:readonly"},
 		Commands:    []string{"doc"},
 	},
 	"bitable": {
@@ -45,23 +45,12 @@ var Groups = map[string]ScopeGroup{
 		Scopes:      []string{"im:message:readonly", "im:message", "im:message:send_as_bot", "im:message.reactions:read", "im:message.reactions:write_only"},
 		Commands:    []string{"msg", "chat"},
 	},
-	"mail": {
-		Name:        "mail",
-		Description: "Email via IMAP",
-		Scopes:      []string{"mail:user_mailbox.message.address:read", "mail:user_mailbox.message.body:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message:readonly"},
-		Commands:    []string{"mail"},
-	},
-	"minutes": {
-		Name:        "minutes",
-		Description: "Meeting recordings and transcripts",
-		Scopes:      []string{"minutes:minutes:readonly", "minutes:minute:download"},
-		Commands:    []string{"minutes"},
-	},
+	// "mail" and "minutes" groups removed: require company-level scope approval
 }
 
 // AllGroupNames returns all scope group names in a consistent order
 func AllGroupNames() []string {
-	return []string{"calendar", "contacts", "documents", "bitable", "messages", "mail", "minutes"}
+	return []string{"calendar", "contacts", "documents", "bitable", "messages"}
 }
 
 // GetScopesForGroups returns the combined scopes for the given group names


### PR DESCRIPTION
## Summary

- Add `LARK_REGION` config to switch between Lark (international) and Feishu (China) API endpoints
- Remove OAuth scopes that require company-level admin approval

## Changes

- `internal/config/config.go`: New `region` field, `LARK_REGION` env var, `GetRegion()` and `GetBaseURL()`
- `internal/auth/oauth.go`: Dynamic URL functions replacing hardcoded `larksuite.com` constants
- `internal/api/client.go`, `internal/api/messages.go`: Use `config.GetBaseURL()` instead of hardcoded `baseURL`
- `internal/scopes/scopes.go`: Remove scopes requiring company approval

Closes #1
Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)