### PR TITLE
feat: add markdown write support for documents

### DIFF
--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -249,6 +249,72 @@ func (c *Client) DownloadDriveFileWithTenant(fileToken string) (io.ReadCloser, s
 	return c.DownloadWithTenantToken(path)
 }
 
+// ConvertMarkdown converts markdown content to document blocks
+// content: markdown content to convert
+// Returns the converted document blocks
+func (c *Client) ConvertMarkdown(content string) ([]DocumentBlock, error) {
+	req := ConvertMarkdownRequest{
+		Content:     content,
+		ContentType: "markdown",
+	}
+
+	var resp ConvertMarkdownResponse
+	if err := c.Post("/docx/v1/documents/blocks/convert", req, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != 0 {
+		return nil, fmt.Errorf("API error %d: %s", resp.Code, resp.Msg)
+	}
+
+	return resp.Data.Blocks, nil
+}
+
+// WriteMarkdownToDocument writes markdown content to a document
+// documentID: the document ID
+// markdown: markdown content to write
+// index: insertion position (-1 for end)
+// Returns the created blocks and revision ID
+func (c *Client) WriteMarkdownToDocument(documentID string, markdown string, index int) ([]DocumentBlock, int, error) {
+	// Convert markdown to blocks
+	blocks, err := c.ConvertMarkdown(markdown)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if len(blocks) == 0 {
+		return nil, 0, fmt.Errorf("no blocks were converted from markdown")
+	}
+
+	// Create blocks in the document
+	return c.CreateDocumentBlocks(documentID, documentID, blocks, index)
+}
+
+// CreateDocumentWithMarkdown creates a new document with markdown content
+// title: document title
+// folderToken: optional folder token (empty for root)
+// markdown: initial markdown content
+// Returns the created document and blocks
+func (c *Client) CreateDocumentWithMarkdown(title, folderToken string, markdown string) (*Document, []DocumentBlock, int, error) {
+	// Create empty document first
+	doc, err := c.CreateDocument(title, folderToken)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	if markdown == "" {
+		return doc, nil, doc.RevisionID, nil
+	}
+
+	// Write markdown content
+	blocks, revisionID, err := c.WriteMarkdownToDocument(doc.DocumentID, markdown, -1)
+	if err != nil {
+		return doc, nil, doc.RevisionID, err
+	}
+
+	return doc, blocks, revisionID, nil
+}
+
 // SearchDocuments searches for documents using the Lark Docs API
 // query: search keyword (required)
 // ownerIDs: optional filter by owner user IDs

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -719,6 +719,21 @@ type CreateBlockChildrenResponse struct {
 	} `json:"data,omitempty"`
 }
 
+// ConvertMarkdownRequest is the request body for POST /docx/v1/document/convert
+type ConvertMarkdownRequest struct {
+	Content      string `json:"content"`                // Markdown content
+	ContentType  string `json:"content_type"`           // "markdown" or "html"
+	ResourceType string `json:"resource_type,omitempty"` // "docx"
+}
+
+// ConvertMarkdownResponse is the response from convert API
+type ConvertMarkdownResponse struct {
+	BaseResponse
+	Data struct {
+		Blocks []DocumentBlock `json:"blocks,omitempty"`
+	} `json:"data,omitempty"`
+}
+
 // OutputDocumentCreate is the create document response for CLI
 type OutputDocumentCreate struct {
 	Success    bool   `json:"success"`
@@ -732,6 +747,23 @@ type OutputDocumentAppend struct {
 	Success            bool            `json:"success"`
 	DocumentRevisionID int             `json:"document_revision_id"`
 	Blocks             []DocumentBlock `json:"blocks,omitempty"`
+}
+
+// OutputDocumentWriteMarkdown is the write markdown response for CLI
+type OutputDocumentWriteMarkdown struct {
+	Success            bool   `json:"success"`
+	DocumentID         string `json:"document_id"`
+	DocumentRevisionID int    `json:"document_revision_id"`
+	BlockCount         int    `json:"block_count"`
+}
+
+// OutputDocumentCreateWithMarkdown is the create with markdown response for CLI
+type OutputDocumentCreateWithMarkdown struct {
+	Success    bool   `json:"success"`
+	DocumentID string `json:"document_id"`
+	RevisionID int    `json:"revision_id"`
+	Title      string `json:"title"`
+	BlockCount int    `json:"block_count,omitempty"`
 }
 
 // --- Document CLI Output Types ---

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -628,35 +628,87 @@ var docCreateCmd = &cobra.Command{
 	Short: "Create a new document",
 	Long: `Create a new Lark document.
 
-Creates an empty document with the specified title.
+Creates a new document with the specified title.
 Optionally specify a folder to create the document in.
+Optionally provide initial markdown content.
+
+Markdown content can be provided via:
+  - --markdown flag: inline markdown text
+  - --file flag: read from a markdown file
+  - stdin: pipe markdown content
 
 Examples:
   lark doc create --title "My Document"
-  lark doc create --title "Project Plan" --folder fldbcRho46N6...`,
+  lark doc create --title "Project Plan" --folder fldbcRho46N6...
+  lark doc create --title "Notes" --markdown "# Heading\n\nContent"
+  lark doc create --title "Notes" --file content.md
+  cat content.md | lark doc create --title "Notes"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		title, _ := cmd.Flags().GetString("title")
 		folderToken, _ := cmd.Flags().GetString("folder")
+		markdownText, _ := cmd.Flags().GetString("markdown")
+		inputFile, _ := cmd.Flags().GetString("file")
 
 		if title == "" {
 			output.Fatal("MISSING_ARG", fmt.Errorf("--title is required"))
 		}
 
+		var markdown string
+		switch {
+		case markdownText != "":
+			markdown = unescapeString(markdownText)
+		case inputFile != "":
+			data, err := os.ReadFile(inputFile)
+			if err != nil {
+				output.Fatal("FILE_ERROR", fmt.Errorf("failed to read file: %w", err))
+			}
+			markdown = string(data)
+		default:
+			// Check if stdin has data
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					output.Fatal("INPUT_ERROR", fmt.Errorf("failed to read stdin: %w", err))
+				}
+				markdown = string(data)
+			}
+		}
+
 		client := api.NewClient()
 
-		doc, err := client.CreateDocument(title, folderToken)
-		if err != nil {
-			output.Fatal("API_ERROR", err)
-		}
+		if markdown == "" {
+			// Create empty document
+			doc, err := client.CreateDocument(title, folderToken)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
 
-		result := api.OutputDocumentCreate{
-			Success:    true,
-			DocumentID: doc.DocumentID,
-			RevisionID: doc.RevisionID,
-			Title:      doc.Title,
-		}
+			result := api.OutputDocumentCreate{
+				Success:    true,
+				DocumentID: doc.DocumentID,
+				RevisionID: doc.RevisionID,
+				Title:      doc.Title,
+			}
 
-		output.JSON(result)
+			output.JSON(result)
+		} else {
+			// Create document with markdown content
+			doc, blocks, revisionID, err := client.CreateDocumentWithMarkdown(title, folderToken, markdown)
+			if err != nil {
+				output.Fatal("API_ERROR", err)
+			}
+
+			result := api.OutputDocumentCreateWithMarkdown{
+				Success:    true,
+				DocumentID: doc.DocumentID,
+				RevisionID: revisionID,
+				Title:      doc.Title,
+				BlockCount: len(blocks),
+			}
+
+			output.JSON(result)
+		}
 	},
 }
 
@@ -833,6 +885,78 @@ Examples:
 	},
 }
 
+// --- doc write-markdown ---
+
+var docWriteMarkdownCmd = &cobra.Command{
+	Use:   "write-markdown <document_id>",
+	Short: "Write markdown content to a document",
+	Long: `Write markdown content to a Lark document.
+
+The markdown is automatically converted to Lark document blocks using
+Feishu's convert API.
+
+Content can be provided via:
+  - --text flag: inline markdown text
+  - --file flag: read from a markdown file
+  - stdin: pipe markdown content
+
+Examples:
+  lark doc write-markdown ABC123xyz --text "# Heading\n\nSome text"
+  lark doc write-markdown ABC123xyz --file content.md
+  cat content.md | lark doc write-markdown ABC123xyz
+  lark doc write-markdown ABC123xyz --text "## Section" --index 0`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		documentID := args[0]
+		markdownText, _ := cmd.Flags().GetString("text")
+		inputFile, _ := cmd.Flags().GetString("file")
+		index, _ := cmd.Flags().GetInt("index")
+
+		var markdown string
+		var err error
+
+		switch {
+		case markdownText != "":
+			// Use text from flag (unescape escape sequences)
+			markdown = unescapeString(markdownText)
+		case inputFile != "":
+			// Read from file
+			data, err := os.ReadFile(inputFile)
+			if err != nil {
+				output.Fatal("FILE_ERROR", fmt.Errorf("failed to read file: %w", err))
+			}
+			markdown = string(data)
+		default:
+			// Read from stdin
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				output.Fatal("INPUT_ERROR", fmt.Errorf("failed to read stdin: %w", err))
+			}
+			markdown = string(data)
+		}
+
+		if markdown == "" {
+			output.Fatal("MISSING_ARG", fmt.Errorf("no markdown content provided (use --text, --file, or pipe from stdin)"))
+		}
+
+		client := api.NewClient()
+
+		blocks, revisionID, err := client.WriteMarkdownToDocument(documentID, markdown, index)
+		if err != nil {
+			output.Fatal("API_ERROR", err)
+		}
+
+		result := api.OutputDocumentWriteMarkdown{
+			Success:            true,
+			DocumentID:         documentID,
+			DocumentRevisionID: revisionID,
+			BlockCount:         len(blocks),
+		}
+
+		output.JSON(result)
+	},
+}
+
 // codeLanguageHelp returns a string listing code language IDs for the help text
 func codeLanguageHelp() string {
 	return "Common language IDs: 1=PlainText, 7=Bash, 8=C#, 9=C++, 10=C, 12=CSS, 22=Go, 24=HTML, 28=JSON, 29=Java, 30=JavaScript, 32=Kotlin, 49=Python, 52=Ruby, 53=Rust, 56=SQL, 61=Swift, 63=TypeScript, 67=YAML"
@@ -852,6 +976,7 @@ func init() {
 	docCmd.AddCommand(docDownloadCmd)
 	docCmd.AddCommand(docCreateCmd)
 	docCmd.AddCommand(docAppendCmd)
+	docCmd.AddCommand(docWriteMarkdownCmd)
 
 	// Flags for doc wiki-search
 	docWikiSearchCmd.Flags().String("space-id", "", "Filter to specific wiki space ID")
@@ -872,6 +997,8 @@ func init() {
 	// Flags for doc create
 	docCreateCmd.Flags().String("title", "", "Document title (required)")
 	docCreateCmd.Flags().String("folder", "", "Folder token to create document in (default: root)")
+	docCreateCmd.Flags().String("markdown", "", "Initial markdown content")
+	docCreateCmd.Flags().String("file", "", "Read initial markdown content from file")
 
 	// Flags for doc append
 	docAppendCmd.Flags().String("block-id", "", "Parent block ID (default: document root)")
@@ -886,4 +1013,9 @@ func init() {
 	docAppendCmd.Flags().Bool("divider", false, "Append a divider")
 	docAppendCmd.Flags().Bool("json", false, "Read raw block JSON from stdin")
 	docAppendCmd.Flags().Int("index", -1, "Insertion position (-1=end, 0=beginning)")
+
+	// Flags for doc write-markdown
+	docWriteMarkdownCmd.Flags().String("text", "", "Markdown text content")
+	docWriteMarkdownCmd.Flags().String("file", "", "Read markdown from file")
+	docWriteMarkdownCmd.Flags().Int("index", -1, "Insertion position (-1=end, 0=beginning)")
 }

--- a/internal/scopes/scopes.go
+++ b/internal/scopes/scopes.go
@@ -30,7 +30,7 @@ var Groups = map[string]ScopeGroup{
 	"documents": {
 		Name:        "documents",
 		Description: "Lark Docs and Drive access",
-		Scopes:      []string{"docx:document:readonly", "docx:document", "docx:document:create", "docs:document.content:read", "docs:document.comment:read", "wiki:wiki:readonly"},
+		Scopes:      []string{"docx:document:readonly", "docx:document", "docx:document:create", "docx:document.block:convert", "docs:document.content:read", "docs:document.comment:read", "wiki:wiki:readonly"},
 		Commands:    []string{"doc"},
 	},
 	"bitable": {

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -14,7 +14,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 ```bash
 lark cal <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/path/to/.lark lark cal <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark lark cal <command>
 ```
 
 ## Before Running Commands

--- a/skills/contacts/SKILL.md
+++ b/skills/contacts/SKILL.md
@@ -14,7 +14,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 ```bash
 lark contact <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/path/to/.lark lark contact <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark lark contact <command>
 ```
 
 ## Commands Reference

--- a/skills/documents/SKILL.md
+++ b/skills/documents/SKILL.md
@@ -14,7 +14,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 ```bash
 lark doc <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/Users/yingcong/Code/lark-cli/.lark lark doc <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark lark doc <command>
 ```
 
 ## Commands Reference

--- a/skills/documents/SKILL.md
+++ b/skills/documents/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documents
-description: Read and write Lark documents - get content as markdown or blocks, create new documents, append content (text, headings, lists, code), list folders. Use when user asks about a Lark doc, wants to read/create/edit a document, or mentions a document URL/ID.
+description: Read and write Lark documents - get content as markdown or blocks, create new documents with markdown, write markdown to existing documents, append content (text, headings, lists, code), list folders. Use when user asks about a Lark doc, wants to read/create/edit a document, or mentions a document URL/ID.
 ---
 
 # Lark Documents Skill
@@ -267,22 +267,81 @@ Fields:
 ### Create a New Document
 
 ```bash
-lark doc create --title "My Document" [--folder <folder-token>]
+lark doc create --title "My Document" [--folder <folder-token>] [--markdown <content>] [--file <path>]
 ```
 
-Creates a new empty Lark document. Optionally specify a folder to create it in.
+Creates a new Lark document. Optionally specify a folder to create it in, and/or provide initial markdown content.
 
 Options:
 - `--title`: Document title (required)
 - `--folder`: Folder token to create the document in (default: root cloud space)
+- `--markdown`: Initial markdown content (inline)
+- `--file`: Read initial markdown content from a file
 
-Output:
+Markdown content can also be provided via stdin:
+```bash
+cat content.md | lark doc create --title "My Document"
+```
+
+Output (empty document):
 ```json
 {
   "success": true,
   "document_id": "BKlmdClegoCan5x5Rzbl73QQgEC",
   "revision_id": 1,
   "title": "My Document"
+}
+```
+
+Output (with markdown):
+```json
+{
+  "success": true,
+  "document_id": "BKlmdClegoCan5x5Rzbl73QQgEC",
+  "revision_id": 2,
+  "title": "My Document",
+  "block_count": 5
+}
+```
+
+### Write Markdown to Document
+
+```bash
+lark doc write-markdown <document-id> [--text <content>] [--file <path>] [--index <position>]
+```
+
+Writes markdown content to an existing document. The markdown is automatically converted to Lark document blocks using Feishu's convert API.
+
+Content options (one required):
+- `--text`: Markdown text content (inline, supports `\n` for line breaks)
+- `--file`: Read markdown from a file
+- stdin: Pipe markdown content
+
+Other options:
+- `--index`: Insertion position (-1=end, 0=beginning, default: -1)
+
+Examples:
+```bash
+# Write markdown via --text flag
+lark doc write-markdown ABC123xyz --text "# Heading\n\nSome text"
+
+# Write markdown from a file
+lark doc write-markdown ABC123xyz --file content.md
+
+# Pipe markdown content
+cat content.md | lark doc write-markdown ABC123xyz
+
+# Insert at the beginning
+lark doc write-markdown ABC123xyz --text "## Section" --index 0
+```
+
+Output:
+```json
+{
+  "success": true,
+  "document_id": "ABC123xyz",
+  "document_revision_id": 5,
+  "block_count": 3
 }
 ```
 
@@ -411,7 +470,9 @@ Output:
 | Download a file | `doc download` | Save Drive files locally |
 | Wiki URL | `doc wiki` then `doc get` | Must resolve wiki node first |
 | List wiki sub-pages | `doc wiki-children` | Browse wiki hierarchy |
-| Create a new document | `doc create` | Creates empty doc with title |
+| Create a new empty document | `doc create --title "..."` | Creates empty doc with title |
+| Create document with markdown | `doc create --title "..." --markdown "..."` | Create and initialize in one step |
+| Write markdown to existing doc | `doc write-markdown` | Convert markdown to Lark blocks automatically |
 | Append content to doc | `doc append` | Add text, headings, lists, code, etc. |
 | Read/summarize content | `doc get` | Markdown is compact (~90KB) |
 | Analyze structure | `doc blocks` | Full block hierarchy |

--- a/skills/email/SKILL.md
+++ b/skills/email/SKILL.md
@@ -24,7 +24,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 ```bash
 lark mail <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/path/to/.lark lark mail <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark lark mail <command>
 ```
 
 ## Commands Reference

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -62,7 +62,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 lark msg <command>
 lark chat <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/path/to/.lark lark msg <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark lark msg <command>
 ```
 
 ## Commands Reference

--- a/skills/minutes/SKILL.md
+++ b/skills/minutes/SKILL.md
@@ -14,7 +14,7 @@ Ensure `lark` is in your PATH, or use the full path to the binary. Set the confi
 ```bash
 lark minutes <command>
 # Or with explicit config:
-LARK_CONFIG_DIR=/path/to/.lark lark minutes <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark lark minutes <command>
 ```
 
 ## Getting the Minute Token

--- a/skills/sheets/SKILL.md
+++ b/skills/sheets/SKILL.md
@@ -15,7 +15,7 @@ tools/bin/lark
 
 Run from the vault root directory with required env var:
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet <command>
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet <command>
 ```
 
 ## Commands Reference
@@ -151,22 +151,22 @@ The sheet_id can be found in the URL query parameter:
 
 ```bash
 # List all sheets first
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet list T4mHsrFyzhXrj0tVzRslUGx8gkA
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet list T4mHsrFyzhXrj0tVzRslUGx8gkA
 
 # Then read specific sheet
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet abc123 --range A1:D20
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet abc123 --range A1:D20
 ```
 
 ### Read Header Row Only
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --range A1:Z1
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --range A1:Z1
 ```
 
 ### Read First 50 Rows of Specific Sheet
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet def456 --range A1:Z50
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read T4mHsrFyzhXrj0tVzRslUGx8gkA --sheet def456 --range A1:Z50
 ```
 
 ## Efficient Extraction with jq
@@ -176,31 +176,31 @@ For large spreadsheets, use `jq` to extract specific data without loading everyt
 ### Get Column Headers
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read <token> --range A1:Z1 | jq '.values[0]'
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read <token> --range A1:Z1 | jq '.values[0]'
 ```
 
 ### Get Row Count
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read <token> | jq '.row_count'
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read <token> | jq '.row_count'
 ```
 
 ### Extract Specific Column (Column B)
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read <token> | jq '[.values[] | .[1]]'
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read <token> | jq '[.values[] | .[1]]'
 ```
 
 ### Find Rows Matching a Value
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read <token> | jq '[.values[] | select(.[0] == "SearchValue")]'
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read <token> | jq '[.values[] | select(.[0] == "SearchValue")]'
 ```
 
 ### Get First N Rows
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark sheet read <token> | jq '.values[:10]'
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark sheet read <token> | jq '.values[:10]'
 ```
 
 ## Output Format
@@ -229,12 +229,12 @@ Common error codes:
 This skill requires the `documents` scope group (uses `drive:drive:readonly`). If you see a `SCOPE_ERROR`, the user needs to add documents permissions:
 
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark auth login --add --scopes documents
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark auth login --add --scopes documents
 ```
 
 To check current permissions:
 ```bash
-LARK_CONFIG_DIR=tools/lark/.lark tools/bin/lark auth status
+LARK_CONFIG_DIR=${HOME}/.config/lark tools/bin/lark auth status
 ```
 
 ## Limitations


### PR DESCRIPTION
## Summary

Add markdown write support for Lark documents and update skills configuration:

### Markdown Write Support (Core Feature)

- **New API methods**:
  - `ConvertMarkdown()` - Convert markdown content to document blocks
  - `WriteMarkdownToDocument()` - Write markdown to existing documents
  - `CreateDocumentWithMarkdown()` - Create documents with initial markdown

- **New CLI commands**:
  - `doc write-markdown <document_id>` - Write markdown to a document
    - Supports `--text`, `--file`, and stdin for input
    - Supports `--index` for insertion position

- **Enhanced commands**:
  - `doc create` now supports markdown content via `--markdown`, `--file`, or stdin

- **New scope**:
  - Added `docx:document.block:convert` for markdown conversion API

### Skill Documentation Updates

- **Updated `lark__documents` skill**:
  - Added documentation for markdown write capabilities
  - Updated `doc create` command docs with markdown options
  - Added `doc write-markdown` command documentation
  - Updated "Which Command to Use" reference table

- **Updated all skills config paths**:
  - Changed `LARK_CONFIG_DIR` from various hardcoded paths to `${HOME}/.config/lark`
  - Updated skills: calendar, contacts, documents, email, messages, minutes, sheets

## Examples

```bash
# Create document with markdown
lark doc create --title "Notes" --markdown "# Heading\n\nContent"
lark doc create --title "Notes" --file content.md
cat content.md | lark doc create --title "Notes"

# Write markdown to existing document
lark doc write-markdown ABC123xyz --text "## Section"
lark doc write-markdown ABC123xyz --file content.md
cat content.md | lark doc write-markdown ABC123xyz
```
